### PR TITLE
Error handling

### DIFF
--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -75,7 +75,7 @@ class TestTypeChecker(unittest.TestCase):
 
         # Then
         self.assertEqual(str(exep.exception),
-                "TypeError: 6 is of type <class 'int'>, not of type <class 'NoneType'>")
+                "6 is of type <class 'int'>, not of type <class 'NoneType'>")
 
     def test_ignore(self):
         # Given
@@ -146,7 +146,7 @@ class TestTypeChecker(unittest.TestCase):
         self.assertEqual(res1, (int, str, float))
         self.assertEqual(res2, (int, str, int))
         self.assertEqual(res3, (int, str, Foo))
-        self.assertTrue(str(exep.exception).startswith("TypeError: FOO"))
+        self.assertTrue(str(exep.exception).startswith("FOO"))
         self.assertTrue(str(exep.exception).endswith("is of type <class 'str'>, not of type (<class '__main__.TestTypeChecker.test_multiple_options_arg.<locals>.Foo'>, <class 'int'>, <class 'float'>)"))
 
     def test_multiple_options_kwarg(self):
@@ -170,7 +170,7 @@ class TestTypeChecker(unittest.TestCase):
         self.assertEqual(res1, (int, str, float))
         self.assertEqual(res2, (int, str, int))
         self.assertEqual(res3, (int, str, Foo))
-        self.assertTrue(str(exep.exception).startswith("TypeError: FOO"))
+        self.assertTrue(str(exep.exception).startswith("FOO"))
         self.assertTrue(str(exep.exception).endswith("is of type <class 'str'>, not of type (<class '__main__.TestTypeChecker.test_multiple_options_kwarg.<locals>.Foo'>, <class 'int'>, <class 'float'>)"))
 
     def test_multiple_options_arg_ignore(self):
@@ -240,7 +240,7 @@ class TestTypeChecker(unittest.TestCase):
 
         # Then
         self.assertEqual(str(exep.exception),
-                "TypeError: 5 is of type <class 'str'>, not of type <class 'int'>")
+                "5 is of type <class 'str'>, not of type <class 'int'>")
 
     def test_not_enough_check_args(self):
         # Given
@@ -405,7 +405,7 @@ class TestTypeChecker(unittest.TestCase):
 
         # Then
         # (Split in two to ignore object address)
-        self.assertTrue(str(exep.exception).startswith("TypeError: <__main__.TestTypeChecker.test_wrong_class_instance_as_argument.<locals>.Foo"))
+        self.assertTrue(str(exep.exception).startswith("<__main__.TestTypeChecker.test_wrong_class_instance_as_argument.<locals>.Foo"))
         self.assertTrue(str(exep.exception).endswith("is of type <class '__main__.TestTypeChecker.test_wrong_class_instance_as_argument.<locals>.Foo'>, not of type <class '__main__.TestTypeChecker.test_wrong_class_instance_as_argument.<locals>.Baz'>"))
 
     def test_check_instance_method_args(self):
@@ -495,7 +495,7 @@ class TestTypeChecker(unittest.TestCase):
 
         # Then
         self.assertEqual(str(exep.exception),
-                "TypeError: 2 is of type <class 'int'>, not of type <class 'str'>")
+                "2 is of type <class 'int'>, not of type <class 'str'>")
 
 
     def test_kwargs_unordered(self):
@@ -522,7 +522,7 @@ class TestTypeChecker(unittest.TestCase):
 
         # Then
         self.assertEqual(str(exep.exception),
-                "TypeError: 1 is of type <class 'int'>, not of type <class 'str'>")
+                "1 is of type <class 'int'>, not of type <class 'str'>")
 
 
     def test_list_as_argument(self):

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -1,5 +1,5 @@
 import unittest
-from typechecker import typecheck
+from typechecker import typecheck, TypeCheckError
 
 class TestTypeChecker(unittest.TestCase):
 
@@ -70,7 +70,7 @@ class TestTypeChecker(unittest.TestCase):
             return i
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             foo(6, 5)
 
         # Then
@@ -139,7 +139,7 @@ class TestTypeChecker(unittest.TestCase):
         res2 = bar(1, "2", 3)
         res3 = bar(1, "2", Foo())
 
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             bar(1, "2", "FOO")
 
         # Then
@@ -163,7 +163,7 @@ class TestTypeChecker(unittest.TestCase):
         res2 = bar(c=1, a=1, b="2")
         res3 = bar(c=Foo(), a=1, b="2")
 
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             bar(c="FOO", a=1, b="2")
 
         # Then
@@ -235,7 +235,7 @@ class TestTypeChecker(unittest.TestCase):
             return bar
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             res = foo("5")
 
         # Then
@@ -249,12 +249,12 @@ class TestTypeChecker(unittest.TestCase):
             return (bar, baz)
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeCheckError) as exep:
             res = foo(1, 2)
 
         # Then
         self.assertEqual(str(exep.exception),
-                f"TypecheckError: Cannot check all arguments given, not enough typecheck args given")
+                f"Cannot check all arguments given, not enough typecheck args given")
 
     def test_to_many_check_args(self):
         # Given
@@ -400,7 +400,7 @@ class TestTypeChecker(unittest.TestCase):
             return obj.get_faz()
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             bar(foo)
 
         # Then
@@ -490,7 +490,7 @@ class TestTypeChecker(unittest.TestCase):
             return (bar, baz)
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             res = foo(bar=1, baz=2)
 
         # Then
@@ -517,7 +517,7 @@ class TestTypeChecker(unittest.TestCase):
             return (bar, baz)
 
         # When
-        with self.assertRaises(Exception) as exep:
+        with self.assertRaises(TypeError) as exep:
             res = foo(baz=1, bar=2)
 
         # Then

--- a/typechecker.py
+++ b/typechecker.py
@@ -3,6 +3,10 @@ from pydoc import locate
 from functools import partial
 import inspect
 
+class TypeCheckError(Exception):
+    """Raise when type-checker cannot check the arguments."""
+    pass
+
 def typecheck(*check_args, **check_kwargs):
     """
         Checks that arguments passed to function
@@ -13,6 +17,7 @@ def typecheck(*check_args, **check_kwargs):
         raise err_type(err_msg)
 
     t_error = partial(error, TypeError)
+    tc_error = partial(error, TypeCheckError)
 
     def get_fn_param(fn):
         return [param.strip() for param in str(inspect.signature(fn)).replace("(", "").replace(")", "").split(",")]
@@ -61,8 +66,8 @@ def typecheck(*check_args, **check_kwargs):
             parse_check_kwargs(func, check_args)
             if not callable(check_args[0]):
                 """ Check types """
-                assert len(check_args) >= (len(args)+len(kwargs)), \
-                        f"TypecheckError: Cannot check all arguments given, not enough typecheck args given"
+                if not len(check_args) >= (len(args)+len(kwargs)):
+                        tc_error(f"Cannot check all arguments given, not enough typecheck args given")
                 # Check args
                 for index, arg in enumerate(args):
                     if check_args[index] == "pass":


### PR DESCRIPTION
This makes sure that when there is a type mismatch,
the type-checker will raise an actual TypeError.

This also introduces an actual TypeCheckError,
that is to be used when the type-checker is not
able to check the arguments.

Issue #7