### PR TITLE
Cleanup of the type-checker code and implementation of implicit parameter ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,49 @@ Doing this will type-check the values
 passed to 'a' and 'c', and ignore checking
 the value passed to 'b'.
 
+Note that it no longer is necessary to
+explicitly set a parameter to 'pass'
+(see examples below), since this is
+done automatically.
+
+```
+from typechecker import typecheck
+
+@typecheck(int, float)
+def foo(a, b, c, d):
+    pass
+```
+
+and
+
+```
+from typechecker import typecheck
+
+@typecheck(c=int, d=float)
+def foo(a, b, c, d):
+    pass
+```
+
+is the same as
+
+```
+from typechecker import typecheck
+
+@typecheck(int, float, 'pass', 'pass')
+def foo(a, b, c, d):
+    pass
+```
+
+and
+
+```
+from typechecker import typecheck
+
+@typecheck('pass', 'pass', int, float)
+def foo(a, b, c, d):
+    pass
+```
+
 ### Multiple Options
 
 ```

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -652,5 +652,19 @@ class TestTypeChecker(unittest.TestCase):
         # Then
         self.assertEqual(res, (1, 2.3, "4"))
 
+
+    def test_set_same_arg_with_kwarg(self):
+        # Given
+        @typecheck(int, a=str)
+        def foo(a, b):
+            pass
+
+        # When
+        with self.assertRaises(TypeCheckError) as e:
+            foo(1, 3)
+
+        # Then
+        self.assertEqual(str(e.exception), "The kwarg a is already set by arg")
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -39,6 +39,19 @@ class TestTypeChecker(unittest.TestCase):
         # Then
         self.assertEqual(res, 5)
 
+    def test_bad_check_kwargs(self):
+        # Given
+        @typecheck(baz=int)
+        def foo(bar):
+            return bar
+
+        # When
+        with self.assertRaises(TypeCheckError) as e:
+            res = foo(5)
+
+        # Then
+        self.assertTrue(str(e.exception).startswith("The given kwarg baz is not a parameter of function <function TestTypeChecker.test_bad_check_kwargs.<locals>.foo at"))
+
     def test_check_multiple_kwargs(self):
         # Given
         @typecheck(baz=int, bar=str)
@@ -249,12 +262,10 @@ class TestTypeChecker(unittest.TestCase):
             return (bar, baz)
 
         # When
-        with self.assertRaises(TypeCheckError) as exep:
-            res = foo(1, 2)
+        res = foo(1, 2)
 
         # Then
-        self.assertEqual(str(exep.exception),
-                f"Cannot check all arguments given, not enough typecheck args given")
+        self.assertEqual(res, (1, 2))
 
     def test_to_many_check_args(self):
         # Given
@@ -617,6 +628,29 @@ class TestTypeChecker(unittest.TestCase):
         # Then
         self.assertEqual(res, 1)
 
+    def test_non_set_check_args(self):
+        # Given
+        @typecheck(int, float)
+        def foo(a, b, c):
+            return (a, b, c)
+
+        # When
+        res = foo(1, 2.3, "4")
+
+        # Then
+        self.assertEqual(res, (1, 2.3, "4"))
+
+    def test_non_set_check_kwargs(self):
+        # Given
+        @typecheck(a=int, c=str)
+        def foo(a, b, c):
+            return (a, b, c)
+
+        # When
+        res = foo(1, 2.3, "4")
+
+        # Then
+        self.assertEqual(res, (1, 2.3, "4"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The code has been cleaned up and commented a bit more so it should now be easier to follow.

Also the type-checker no longer need the user to explicitly set parameters to be ignored,
if a parameter has not been given a type to check it will be assumed that it should be ignored.

Issues #5 and #9