### PR TITLE
Added the option to check return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ can be used to ensure that the correct type is passed to functions.
 4. Functions as Arguments
 5. Class instance as Arguments
 6. Checking Class and Instance Methods
+7. Checking return type
 
 ### Basic Usage
 
@@ -175,3 +176,27 @@ you need to set the first parameter to 'pass' due to them
 taking a reference to the instance or the class. Also note
 that the order of decorators matter, the type-checker
 needs to be the last decorator added.
+
+### Checking return type
+
+It is possible to check the return type of the function as well.
+
+The following will work fine:
+
+```
+@typecheck(int, b=float, check_return_type=str)
+def foo(a, b):
+    return str(a/b)
+```
+
+and this will raise a TypeError:
+
+```
+@typecheck(int, b=float, check_return_type=str)
+def foo(a, b):
+    return a/b
+```
+
+Note that the keyword-argument 'check\_return\_type' is reserved by
+the type-checker, meaning that if you want to use the type-checker
+your function can't have a parameter with the same name.

--- a/typechecker.py
+++ b/typechecker.py
@@ -7,7 +7,7 @@ class TypeCheckError(Exception):
     """Raise when type-checker cannot check the arguments."""
     pass
 
-def typecheck(*check_args, **check_kwargs):
+def typecheck(*check_args, check_return_type='unset', **check_kwargs):
     """
         Checks that arguments passed to function
         is of the type passed to the type checker.
@@ -126,7 +126,14 @@ def typecheck(*check_args, **check_kwargs):
                          t_error(f"The value '{values[param]}' sent to parameter '{param}' "\
                                  f"of function '{get_fn_name(func)}' is of type {type(values[param])}, expected type {arg_type}")
 
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+
+            if check_return_type is not 'unset' and not isinstance(result, check_return_type):
+                t_error(f"The value '{result}' returned from function '{get_fn_name(func)}' is of type {type(result)}, "\
+                f"expected type {check_return_type}")
+            else:
+                return result
+
         return typechecking
 
     def nocheckwrapper(func):


### PR DESCRIPTION
Using the reserved keyword-argument 'check_return_type' the user can also use the type-checker to enforce that the function returns the correct type.

Issue #11