### PR TITLE
Set default values to be ignored

### DIFF
--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -797,6 +797,56 @@ class TestTypeChecker(unittest.TestCase):
         # Then
         self.assertEqual(res, (1, "2", 3.0))
 
+    def test_ignore_default_values_args(self):
+        # Given
+        @typecheck(int, float, str)
+        def foo(a=1, b=1.1, c="1"):
+            return (a, b, c)
+
+        # When
+        res = foo(2, 2.2, "2")
+
+        # Then
+        self.assertEqual(res, (2, 2.2, "2"))
+
+    def test_ignore_default_values_kwargs(self):
+        # Given
+        @typecheck(a=int, b=float, c=str)
+        def foo(a=1, b=1.1, c="1"):
+            return (a, b, c)
+
+        # When
+        res = foo(2, 2.2, "2")
+
+        # Then
+        self.assertEqual(res, (2, 2.2, "2"))
+
+    def test_ignore_default_values_and_type_hints_args(self):
+        # Given
+        @typecheck(int, float, str)
+        def foo(a:int = 1, b:float = 1.1, c:str = "1"):
+            return (a, b, c)
+
+        # When
+        res = foo(2, 2.2, "2")
+
+        # Then
+        self.assertEqual(res, (2, 2.2, "2"))
+
+    def test_ignore_default_values_and_type_hints_kwargs(self):
+        # Given
+        @typecheck(a=int, b=float, c=str)
+        def foo(a:int = 1, b:float = 1.1, c:str = "1"):
+            return (a, b, c)
+
+        # When
+        res = foo(2, 2.2, "2")
+
+        # Then
+        self.assertEqual(res, (2, 2.2, "2"))
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/typechecker.py
+++ b/typechecker.py
@@ -28,6 +28,9 @@ def typecheck(*check_args, check_return_type='unset', **check_kwargs):
         # Remove type hints
         params = [param.split(':')[0] for param in params]
 
+        # Remove default values
+        params = [param.split('=')[0] for param in params]
+
         return params
 
     def get_fn_name(fn):


### PR DESCRIPTION
In order to not break the type-checker
when using default values the get_fn_param
function will now filter out the default
values.

Part of issue #15