### PR TITLE
Ignore type hints and default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ can be used to ensure that the correct type is passed to functions.
 4. Functions as Arguments
 5. Class instance as Arguments
 6. Checking Class and Instance Methods
-7. Checking return type
+7. Checking Return Type
+8. Type Hints and Default Values
 
 ### Basic Usage
 
@@ -177,7 +178,7 @@ taking a reference to the instance or the class. Also note
 that the order of decorators matter, the type-checker
 needs to be the last decorator added.
 
-### Checking return type
+### Checking Return Type
 
 It is possible to check the return type of the function as well.
 
@@ -206,3 +207,11 @@ def foo(a, b):
 Note that the keyword-argument 'check\_return\_type' is reserved by
 the type-checker, meaning that if you want to use the type-checker
 your function can't have a parameter with the same name.
+
+### Type Hints and Default Values
+
+Currently the type-checker ignores type hints and default values.
+This means that there can be a mismatch between the type hints and
+what the type-checker expects (without any issues). Also, if there
+is a default value and the type-checker expects a value to check,
+it will throw an error if no value is given.

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -824,7 +824,7 @@ class TestTypeChecker(unittest.TestCase):
     def test_ignore_default_values_and_type_hints_args(self):
         # Given
         @typecheck(int, float, str)
-        def foo(a:int = 1, b:float = 1.1, c:str = "1"):
+        def foo(a:str = 1, b:float = 1.1, c:str = "1"):
             return (a, b, c)
 
         # When

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -845,6 +845,20 @@ class TestTypeChecker(unittest.TestCase):
         # Then
         self.assertEqual(res, (2, 2.2, "2"))
 
+    def test_ignore_default_value_error(self):
+        # Given
+        @typecheck(int, str)
+        def foo(a, b=None):
+            return (a, b)
+
+        # When
+        with self.assertRaises(TypeCheckError) as e:
+            res = foo(1)
+
+        # Then
+        self.assertEqual(str(e.exception), \
+                "The parameter 'b' got no value, expected type <class 'str'>")
+
 
 
 

--- a/test_typechecker.py
+++ b/test_typechecker.py
@@ -773,6 +773,30 @@ class TestTypeChecker(unittest.TestCase):
                 "expected type (<class 'float'>, <class 'int'>)"))
 
 
+    def test_ignore_type_hints_args(self):
+        # Given
+        @typecheck(int, str, float, check_return_type=tuple)
+        def foo(a: int, b: str, c: float) -> tuple:
+            return (a, b, c)
+
+        # When
+        res = foo(1, "2", 3.0)
+
+        # Then
+        self.assertEqual(res, (1, "2", 3.0))
+
+    def test_ignore_type_hints_kwargs(self):
+        # Given
+        @typecheck(a=int, c=float, b=str, check_return_type=tuple)
+        def foo(a: int, b: str, c: float) -> tuple:
+            return (a, b, c)
+
+        # When
+        res = foo(1, "2", 3.0)
+
+        # Then
+        self.assertEqual(res, (1, "2", 3.0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/typechecker.py
+++ b/typechecker.py
@@ -104,6 +104,7 @@ def typecheck(*check_args, check_return_type='unset', **check_kwargs):
                     'callable' if str(parse_arg) == '<built-in function callable>' else \
                     str(parse_arg).replace("<class '", "").replace("'>", "")
 
+
     def wrapper(func):
         @wraps(func)
         def typechecking(*args, **kwargs):
@@ -131,6 +132,9 @@ def typecheck(*check_args, check_return_type='unset', **check_kwargs):
                              arg_type = check_types[param][0]
                          else:
                              arg_type = tuple(check_types[param]) # If optional types
+
+                     if values[param] == 'unset':
+                         tc_error(f"The parameter '{param}' got no value, expected type {arg_type}")
 
                      if not isinstance(values[param], arg_type):
                          t_error(f"The value '{values[param]}' sent to parameter '{param}' "\

--- a/typechecker.py
+++ b/typechecker.py
@@ -21,7 +21,14 @@ def typecheck(*check_args, check_return_type='unset', **check_kwargs):
 
     def get_fn_param(fn):
         """ Returns a list of parameters belonging to fn """
-        return [param.strip() for param in str(inspect.signature(fn)).replace("(", "").replace(")", "").split(",")]
+
+        # Get parameter list
+        params = [param.strip() for param in str(inspect.signature(fn)).replace("(", "").replace(")", "").split(",")]
+
+        # Remove type hints
+        params = [param.split(':')[0] for param in params]
+
+        return params
 
     def get_fn_name(fn):
         """ Returns a string of the functions name """


### PR DESCRIPTION
These changes ensures that the type-checker no longer breaks when
using type hints and default values.

Issue #15